### PR TITLE
pass options from the original options to get

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ RiakDOWN.prototype._get = function (key, options, callback) {
                 resolved = JSON.stringify(resolved);
             }
 
-            self._put(key, resolved, { bucket: bucket, vclock: reply.vclock }, function (err) {
+            self._put(key, resolved, util._extend(newoptions, { bucket: bucket, vclock: reply.vclock }), function (err) {
                 self._get(key, options, callback);
             });
         });


### PR DESCRIPTION
Specifically, the content_type wasn't being set on the put which was changing the return type I expected. Additionally, the consumer can modify options in a custom siblingResolver and they will be reflected on the put.

Note: I couldn't get the pre-commit to work locally, but testing against the application I am using it in worked.
